### PR TITLE
fix(ci,deps): replace 'upstash' with '@upstash/redis' to unblock CI install

### DIFF
--- a/lib/rateLimiter.ts
+++ b/lib/rateLimiter.ts
@@ -1,4 +1,4 @@
-import { Redis } from 'upstash'
+import { Redis } from '@upstash/redis'
 
 // In-memory store for development
 const memoryStore = new Map<string, { count: number; resetTime: number }>()
@@ -8,8 +8,8 @@ let redis: Redis | null = null
 
 if (process.env.UPSTASH_REDIS_REST_URL && process.env.UPSTASH_REDIS_REST_TOKEN) {
   redis = new Redis({
-    url: process.env.UPSTASH_REDIS_REST_URL,
-    token: process.env.UPSTASH_REDIS_REST_TOKEN,
+    url: process.env.UPSTASH_REDIS_REST_URL!,
+    token: process.env.UPSTASH_REDIS_REST_TOKEN!,
   })
 }
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "web-push": "^3.6.7",
     "@sentry/nextjs": "^8.15.0",
     "web-vitals": "^4.2.0",
-    "upstash": "^1.0.0",
+    "@upstash/redis": "^1.28.3",
     "dompurify": "^3.0.8",
     "jsdom": "^25.0.0"
   },


### PR DESCRIPTION
CI failed with ETARGET: 'upstash@^1.0.0' does not exist. Replace with official '@upstash/redis' and update import in lib/rateLimiter.ts. No behavior change; env-driven Redis client still optional. Ready to merge to green the pipeline.