### PR TITLE
Harden email sending safeguards (dedupe fail-closed, publish & digest)

### DIFF
--- a/app/api/drafts/publish/route.ts
+++ b/app/api/drafts/publish/route.ts
@@ -23,6 +23,8 @@ export async function POST(request: NextRequest) {
   let createdItemIds: string[] = []
   let draft: any = null
   let user: any = null
+  /** Non-blocking user-visible hint if sale-created confirmation email did not send. */
+  let saleCreatedEmailNotice: string | undefined
 
   try {
     const supabase = await createSupabaseServerClient()
@@ -574,42 +576,83 @@ export async function POST(request: NextRequest) {
           // Use user's timezone or default to America/New_York
           const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone || 'America/New_York'
 
-          // Send email using the new comprehensive function (non-blocking)
-          const { sendSaleCreatedEmail } = await import('@/lib/email/sales')
-          const emailResult = await sendSaleCreatedEmail({
-            sale: saleData as any, // Type assertion needed due to Supabase query result type
-            owner: {
-              email: user.email,
-              displayName,
-            },
-            timezone,
+          const { canSendEmail, recordEmailSend } = await import('@/lib/email/emailLog')
+          const saleCreatedDedupeKey = `sale_created:${createdSaleId}`
+          const dedupeGate = await canSendEmail({
+            profileId: user.id,
+            emailType: 'sale_created_confirmation',
+            dedupeKey: saleCreatedDedupeKey,
+            lookbackWindow: '7 days',
           })
-          
-          // Log email result for debugging (non-blocking, doesn't affect response)
-          if (!emailResult.ok) {
-            const { logger } = await import('@/lib/log')
-            logger.warn('Sale created email send failed (non-critical)', {
-              component: 'drafts/publish',
-              operation: 'send_email',
-              draftId: draft.id,
-              saleId: createdSaleId ?? undefined,
-              userId: user.id,
-              ownerEmail: user.email,
-              error: emailResult.error || 'Unknown error',
-              // Include email config status for debugging
-              emailsEnabled: process.env.LOOTAURA_ENABLE_EMAILS === 'true',
-              hasResendApiKey: !!process.env.RESEND_API_KEY,
-              hasResendFromEmail: !!process.env.RESEND_FROM_EMAIL,
+
+          if (!dedupeGate.allowed) {
+            if (dedupeGate.reason === 'duplicate') {
+              saleCreatedEmailNotice =
+                'Sale confirmation email was not sent (already sent recently for this sale).'
+            } else {
+              saleCreatedEmailNotice =
+                'Sale confirmation email was not sent (verification unavailable). Your sale is still published.'
+            }
+          } else {
+            const { sendSaleCreatedEmail } = await import('@/lib/email/sales')
+            const emailResult = await sendSaleCreatedEmail({
+              sale: saleData as any, // Type assertion needed due to Supabase query result type
+              owner: {
+                email: user.email,
+                displayName,
+              },
+              timezone,
+              dedupeKey: saleCreatedDedupeKey,
             })
-          } else if (process.env.NEXT_PUBLIC_DEBUG === 'true') {
-            console.log('[DRAFTS/PUBLISH] Sale created email sent successfully:', {
-              saleId: createdSaleId,
-              ownerEmail: user.email,
-            })
+
+            const saleCreatedSubject = `Your yard sale is live on LootAura 🚀`
+            if (emailResult.ok) {
+              await recordEmailSend({
+                profileId: user.id,
+                emailType: 'sale_created_confirmation',
+                toEmail: user.email,
+                subject: saleCreatedSubject,
+                dedupeKey: saleCreatedDedupeKey,
+                deliveryStatus: 'sent',
+                meta: { saleId: createdSaleId, source: 'draft_publish' },
+              })
+            } else {
+              const { logger } = await import('@/lib/log')
+              logger.warn('Sale created email send failed (non-critical)', {
+                component: 'drafts/publish',
+                operation: 'send_email',
+                draftId: draft.id,
+                saleId: createdSaleId ?? undefined,
+                userId: user.id,
+                ownerEmail: user.email,
+                error: emailResult.error || 'Unknown error',
+                emailsEnabled: process.env.LOOTAURA_ENABLE_EMAILS === 'true',
+                hasResendApiKey: !!process.env.RESEND_API_KEY,
+                hasResendFromEmail: !!process.env.RESEND_FROM_EMAIL,
+              })
+              await recordEmailSend({
+                profileId: user.id,
+                emailType: 'sale_created_confirmation',
+                toEmail: user.email,
+                subject: saleCreatedSubject,
+                dedupeKey: saleCreatedDedupeKey,
+                deliveryStatus: 'failed',
+                errorMessage: 'Email send failed',
+                meta: { saleId: createdSaleId, source: 'draft_publish' },
+              })
+              saleCreatedEmailNotice =
+                'Sale confirmation email could not be sent. Your sale is still published; check email settings or spam folder.'
+            }
+
+            if (emailResult.ok && process.env.NEXT_PUBLIC_DEBUG === 'true') {
+              console.log('[DRAFTS/PUBLISH] Sale created email sent successfully:', {
+                saleId: createdSaleId,
+                ownerEmail: user.email,
+              })
+            }
           }
         }
       } catch (emailError) {
-        // Log but don't fail - email is non-critical
         const { logger } = await import('@/lib/log')
         logger.warn('Failed to trigger sale created confirmation email (non-critical)', {
           component: 'drafts/publish',
@@ -618,10 +661,17 @@ export async function POST(request: NextRequest) {
           userId: user.id,
           error: emailError instanceof Error ? emailError.message : String(emailError),
         })
+        saleCreatedEmailNotice =
+          'Sale confirmation email could not be sent. Your sale is still published; try again later or check spam.'
       }
     }
-    
-    return ok({ data: { saleId: createdSaleId ?? undefined } })
+
+    return ok({
+      data: {
+        saleId: createdSaleId ?? undefined,
+        ...(saleCreatedEmailNotice && { saleCreatedEmailNotice }),
+      },
+    })
   } catch (e: any) {
     const { logger } = await import('@/lib/log')
     const { isProduction } = await import('@/lib/env')

--- a/app/api/webhooks/stripe/route.ts
+++ b/app/api/webhooks/stripe/route.ts
@@ -361,7 +361,7 @@ async function finalizeDraftPromotion(
             lookbackWindow: '7 days', // Prevent duplicates for a week
           })
 
-          if (canSend) {
+          if (canSend.allowed) {
             // Fetch full sale data for email
             const { data: saleData } = await fromBase(admin, 'sales')
               .select('*')
@@ -443,12 +443,18 @@ async function finalizeDraftPromotion(
               }
             }
           } else if (process.env.NEXT_PUBLIC_DEBUG === 'true') {
-            logger.info('Sale created email skipped - already sent (idempotent)', {
-              component: 'webhooks/stripe',
-              operation: 'send_email',
-              saleId: createdSaleId,
-              paymentIntentId,
-            })
+            logger.info(
+              canSend.reason === 'duplicate'
+                ? 'Sale created email skipped - already sent (idempotent)'
+                : 'Sale created email skipped - dedupe check failed (fail closed)',
+              {
+                component: 'webhooks/stripe',
+                operation: 'send_email',
+                saleId: createdSaleId,
+                paymentIntentId,
+                dedupeReason: canSend.reason,
+              }
+            )
           }
         }
       }

--- a/lib/email/emailLog.ts
+++ b/lib/email/emailLog.ts
@@ -17,11 +17,17 @@ export interface RecordEmailSendOptions {
 }
 
 export interface CanSendEmailOptions {
-  profileId: string
+  /** Owner profile UUID, or `null` for system emails (e.g. moderation digest) where `email_log.profile_id` is null. */
+  profileId: string | null
   emailType: string
   dedupeKey: string
   lookbackWindow?: string // PostgreSQL interval, e.g. '1 day' or '7 days'
 }
+
+/** `duplicate` = row exists in window. `dedupe_error` = query failed (send must not proceed). */
+export type CanSendEmailResult =
+  | { allowed: true }
+  | { allowed: false; reason: 'duplicate' | 'dedupe_error' }
 
 /**
  * Record an email send in the email_log table
@@ -91,14 +97,10 @@ export async function recordEmailSend(options: RecordEmailSendOptions): Promise<
 }
 
 /**
- * Check if an email with the given dedupe key was already sent recently
- * 
- * This can be used to prevent duplicate emails within a time window.
- * 
- * @param options - Deduplication check parameters
- * @returns Promise<boolean> - true if email was already sent, false if it's safe to send
+ * Check if an email with the given dedupe key was already sent recently.
+ * On query failure, returns `{ allowed: false, reason: 'dedupe_error' }` (fail closed).
  */
-export async function canSendEmail(options: CanSendEmailOptions): Promise<boolean> {
+export async function canSendEmail(options: CanSendEmailOptions): Promise<CanSendEmailResult> {
   const {
     profileId,
     emailType,
@@ -106,52 +108,63 @@ export async function canSendEmail(options: CanSendEmailOptions): Promise<boolea
     lookbackWindow = '1 day',
   } = options
 
+  const profileLabel =
+    profileId === null ? 'system(null)' : `${profileId.substring(0, 8)}...`
+
   try {
     const admin = getAdminDb()
 
-    // Query for recent emails with matching dedupe key
-    const { data, error } = await fromBase(admin, 'email_log')
+    let query = fromBase(admin, 'email_log')
       .select('id')
-      .eq('profile_id', profileId)
       .eq('email_type', emailType)
       .eq('dedupe_key', dedupeKey)
       .gte('sent_at', `now() - interval '${lookbackWindow}'`)
       .limit(1)
 
+    if (profileId === null) {
+      query = query.is('profile_id', null)
+    } else {
+      query = query.eq('profile_id', profileId)
+    }
+
+    const { data, error } = await query
+
     if (error) {
-      // On error, allow sending (fail open) but log the error
-      console.warn('[EMAIL_LOG] Error checking dedupe, allowing send:', {
-        profileId: profileId.substring(0, 8) + '...',
+      console.error('[EMAIL_LOG] Dedupe check failed — blocking send (fail closed):', {
+        profileId: profileLabel,
         emailType,
         dedupeKey,
         error: error.message,
+        errorCode: (error as { code?: string }).code,
       })
-      return true // Fail open - allow sending if we can't check
+      return { allowed: false, reason: 'dedupe_error' }
     }
 
-    // If we found a matching email, it was already sent
     const alreadySent = data && data.length > 0
 
     if (alreadySent && process.env.NEXT_PUBLIC_DEBUG === 'true') {
       console.log('[EMAIL_LOG] Duplicate email detected, skipping send:', {
-        profileId: profileId.substring(0, 8) + '...',
+        profileId: profileLabel,
         emailType,
         dedupeKey,
         lookbackWindow,
       })
     }
 
-    return !alreadySent // Return true if NOT already sent (safe to send)
+    if (alreadySent) {
+      return { allowed: false, reason: 'duplicate' }
+    }
+
+    return { allowed: true }
   } catch (error) {
-    // On unexpected error, fail open (allow sending)
     const errorMessage = error instanceof Error ? error.message : String(error)
-    console.warn('[EMAIL_LOG] Unexpected error checking dedupe, allowing send:', {
-      profileId: profileId.substring(0, 8) + '...',
+    console.error('[EMAIL_LOG] Unexpected error checking dedupe — blocking send (fail closed):', {
+      profileId: profileLabel,
       emailType,
       dedupeKey,
       error: errorMessage,
     })
-    return true // Fail open - allow sending if we can't check
+    return { allowed: false, reason: 'dedupe_error' }
   }
 }
 

--- a/lib/email/favorites.ts
+++ b/lib/email/favorites.ts
@@ -237,14 +237,20 @@ export async function sendFavoriteSalesStartingSoonDigestEmail(
         lookbackWindow: '1 day',
       })
       
-      if (!canSend) {
-        if (process.env.NEXT_PUBLIC_DEBUG === 'true') {
+      if (!canSend.allowed) {
+        if (canSend.reason === 'duplicate' && process.env.NEXT_PUBLIC_DEBUG === 'true') {
           console.log('[EMAIL_FAVORITES] Skipping duplicate email (already sent in last 24h):', {
             profileId,
             dedupeKey,
           })
         }
-        return { ok: false, error: 'Email already sent recently' }
+        return {
+          ok: false,
+          error:
+            canSend.reason === 'duplicate'
+              ? 'Email already sent recently'
+              : 'Email not sent (dedupe check unavailable)',
+        }
       }
     }
 

--- a/lib/email/featuredSales.ts
+++ b/lib/email/featuredSales.ts
@@ -110,14 +110,20 @@ export async function sendFeaturedSalesEmail(
       lookbackWindow: '7 days',
     })
     
-    if (!canSend) {
-      if (process.env.NEXT_PUBLIC_DEBUG === 'true') {
+    if (!canSend.allowed) {
+      if (canSend.reason === 'duplicate' && process.env.NEXT_PUBLIC_DEBUG === 'true') {
         console.log('[EMAIL_FEATURED_SALES] Skipping duplicate email (already sent for this week):', {
           profileId,
           dedupeKey,
         })
       }
-      return { ok: false, error: 'Email already sent for this week' }
+      return {
+        ok: false,
+        error:
+          canSend.reason === 'duplicate'
+            ? 'Email already sent for this week'
+            : 'Email not sent (dedupe check unavailable)',
+      }
     }
 
     // Generate unsubscribe token and URL

--- a/lib/email/moderationDigest.ts
+++ b/lib/email/moderationDigest.ts
@@ -6,7 +6,7 @@
 import React from 'react'
 import { sendEmail } from './sendEmail'
 import { ModerationDailyDigestEmail, buildModerationDigestSubject, type ReportDigestItem } from './templates/ModerationDailyDigestEmail'
-import { recordEmailSend } from './emailLog'
+import { canSendEmail, recordEmailSend } from './emailLog'
 import { getWeekKey } from '@/lib/featured-email/selection'
 
 export interface SendModerationDailyDigestEmailParams {
@@ -22,7 +22,7 @@ export interface SendModerationDailyDigestEmailParams {
  */
 export async function sendModerationDailyDigestEmail(
   params: SendModerationDailyDigestEmailParams
-): Promise<{ ok: boolean; error?: string }> {
+): Promise<{ ok: boolean; error?: string; skipped?: boolean }> {
   const { reports, dateWindow, baseUrl = 'https://lootaura.com' } = params
 
   // Require MODERATION_DIGEST_EMAIL to be set (fail closed if missing)
@@ -39,6 +39,32 @@ export async function sendModerationDailyDigestEmail(
       ok: false,
       error: 'MODERATION_DIGEST_EMAIL not configured',
     }
+  }
+
+  const weekDedupeKey = `moderation_digest_${getWeekKey(new Date())}`
+  const dedupeGate = await canSendEmail({
+    profileId: null,
+    emailType: 'moderation_daily_digest',
+    dedupeKey: weekDedupeKey,
+    lookbackWindow: '14 days',
+  })
+
+  if (!dedupeGate.allowed) {
+    const { logger } = await import('@/lib/log')
+    if (dedupeGate.reason === 'duplicate') {
+      logger.info('Moderation digest skipped — already sent this week', {
+        component: 'email',
+        operation: 'moderation_digest',
+        dedupeKey: weekDedupeKey,
+      })
+      return { ok: true, skipped: true }
+    }
+    logger.warn('Moderation digest skipped — dedupe check failed (fail closed)', {
+      component: 'email',
+      operation: 'moderation_digest',
+      dedupeKey: weekDedupeKey,
+    })
+    return { ok: false, error: 'Dedupe check failed; moderation digest not sent' }
   }
 
   const subject = buildModerationDigestSubject(reports.length)
@@ -66,7 +92,7 @@ export async function sendModerationDailyDigestEmail(
       emailType: 'moderation_daily_digest',
       toEmail,
       subject,
-      dedupeKey: `moderation_digest_${getWeekKey(new Date())}`, // One per week
+      dedupeKey: weekDedupeKey,
       deliveryStatus: result.ok ? 'sent' : 'failed',
       errorMessage: result.error,
       meta: {
@@ -85,7 +111,7 @@ export async function sendModerationDailyDigestEmail(
       emailType: 'moderation_daily_digest',
       toEmail,
       subject,
-      dedupeKey: `moderation_digest_${getWeekKey(new Date())}`,
+      dedupeKey: weekDedupeKey,
       deliveryStatus: 'failed',
       errorMessage,
       meta: {

--- a/lib/email/sellerAnalytics.ts
+++ b/lib/email/sellerAnalytics.ts
@@ -130,14 +130,20 @@ export async function sendSellerWeeklyAnalyticsEmail(
         lookbackWindow: '7 days',
       })
       
-      if (!canSend) {
-        if (process.env.NEXT_PUBLIC_DEBUG === 'true') {
+      if (!canSend.allowed) {
+        if (canSend.reason === 'duplicate' && process.env.NEXT_PUBLIC_DEBUG === 'true') {
           console.log('[EMAIL_SELLER_ANALYTICS] Skipping duplicate email (already sent for this week):', {
             profileId,
             dedupeKey,
           })
         }
-        return { ok: false, error: 'Email already sent for this week' }
+        return {
+          ok: false,
+          error:
+            canSend.reason === 'duplicate'
+              ? 'Email already sent for this week'
+              : 'Email not sent (dedupe check unavailable)',
+        }
       }
     }
 

--- a/tests/integration/api/webhooks.stripe.email.test.ts
+++ b/tests/integration/api/webhooks.stripe.email.test.ts
@@ -286,7 +286,7 @@ describe('Stripe webhook - finalizeDraftPromotion email sending', () => {
     // Default: email can be sent (not already sent)
     // Reset to default state - each test should explicitly set its own expectations
     mockCanSendEmail.mockReset()
-    mockCanSendEmail.mockResolvedValue(true)
+    mockCanSendEmail.mockResolvedValue({ allowed: true })
     mockSendSaleCreatedEmail.mockReset()
     mockSendSaleCreatedEmail.mockResolvedValue({ ok: true })
     mockRecordEmailSend.mockReset()
@@ -370,7 +370,7 @@ describe('Stripe webhook - finalizeDraftPromotion email sending', () => {
 
   it('should not send duplicate email on repeated webhook invocation with same payment intent', async () => {
     // First invocation - email can be sent
-    mockCanSendEmail.mockResolvedValueOnce(true)
+    mockCanSendEmail.mockResolvedValueOnce({ allowed: true })
     
     const request1 = createStripeWebhookRequest()
     const response1 = await POST(request1)
@@ -384,7 +384,7 @@ describe('Stripe webhook - finalizeDraftPromotion email sending', () => {
     vi.clearAllMocks()
     
     // Mock that email was already sent (idempotency check returns false)
-    mockCanSendEmail.mockResolvedValueOnce(false)
+    mockCanSendEmail.mockResolvedValueOnce({ allowed: false, reason: 'duplicate' })
 
     // Setup mocks for second invocation (idempotent path)
     // Draft is already deleted, so return null
@@ -574,7 +574,7 @@ describe('Stripe webhook - finalizeDraftPromotion email sending', () => {
     // Gate condition 6: canSendEmail() returns true (email not already sent)
     // Explicitly mock and track calls
     mockCanSendEmail.mockClear()
-    mockCanSendEmail.mockResolvedValueOnce(true)
+    mockCanSendEmail.mockResolvedValueOnce({ allowed: true })
 
     // Gate condition 7: sendSaleCreatedEmail() fails
     // Explicitly mock and track calls
@@ -682,7 +682,7 @@ describe('Stripe webhook - finalizeDraftPromotion email sending', () => {
     // This ensures test isolation - no prior test state affects this test
     // We need canSendEmail to return true so the email block is reached
     mockCanSendEmail.mockReset()
-    mockCanSendEmail.mockResolvedValueOnce(true)
+    mockCanSendEmail.mockResolvedValueOnce({ allowed: true })
 
     // Ensure sendSaleCreatedEmail is set to fail (already set above, but be explicit)
     mockSendSaleCreatedEmail.mockReset()
@@ -719,7 +719,7 @@ describe('Stripe webhook - finalizeDraftPromotion email sending', () => {
         })
       )
       const canSendResult = await mockCanSendEmail.mock.results[0].value
-      expect(canSendResult).toBe(true)
+      expect(canSendResult).toEqual({ allowed: true })
     }
 
     // Assert: sendSaleCreatedEmail was called once (proves we attempted to send)

--- a/tests/unit/email/favorites.test.ts
+++ b/tests/unit/email/favorites.test.ts
@@ -14,7 +14,7 @@ vi.mock('@/lib/email/sendEmail', () => ({
 }))
 
 vi.mock('@/lib/email/emailLog', () => ({
-  canSendEmail: vi.fn().mockResolvedValue(true),
+  canSendEmail: vi.fn().mockResolvedValue({ allowed: true }),
   recordEmailSend: vi.fn().mockResolvedValue(undefined),
   generateFavoritesDigestDedupeKey: vi.fn((profileId: string) => `dedupe-${profileId}`),
 }))

--- a/tests/unit/email/sellerAnalytics.test.ts
+++ b/tests/unit/email/sellerAnalytics.test.ts
@@ -9,7 +9,7 @@ vi.mock('@/lib/email/sendEmail', () => ({
 }))
 
 vi.mock('@/lib/email/emailLog', () => ({
-  canSendEmail: vi.fn().mockResolvedValue(true),
+  canSendEmail: vi.fn().mockResolvedValue({ allowed: true }),
   recordEmailSend: vi.fn().mockResolvedValue(undefined),
   generateSellerWeeklyDedupeKey: vi.fn((_profileId: string, _weekStart: Date) => 'dedupe-week'),
 }))


### PR DESCRIPTION
## Summary
Implements audit follow-ups without architecture changes.

### Changes
1. **\canSendEmail\ (\lib/email/emailLog.ts\)** — DB/query errors return \{ allowed: false, reason: 'dedupe_error' }\ (fail closed) with clear error logs. Duplicates return \eason: 'duplicate'\.
2. **Call sites** — favorites, featured sales, seller analytics, Stripe webhook use \.allowed\ / \.reason\.
3. **Draft publish** — \canSendEmail\ with \sale_created:\\ before \sendSaleCreatedEmail\; \ecordEmailSend\ after attempt (sent/failed) aligned with Stripe. Optional \saleCreatedEmailNotice\ on skip/failure (publish still succeeds).
4. **Moderation digest** — \canSendEmail\ before send; same weekly dedupe key as \ecordEmailSend\.
5. **Tests** — mocks return \{ allowed: true }\ for \canSendEmail\.

### Behavior
- Duplicate or dedupe DB failure: no extra send where gated.
- Publish API: success payload may include \saleCreatedEmailNotice\ string (additive, non-breaking).

No retries, queues, schema, or version bumps.